### PR TITLE
feat: キーワード検索パイプライン実装

### DIFF
--- a/convert_xml_to_json/scripts/parser.py
+++ b/convert_xml_to_json/scripts/parser.py
@@ -35,6 +35,38 @@ def parse_ipc_entry(ipc_str):
     # fallback: 空白除去
     return {'code': s.replace(' ', ''), 'raw': ipc_str.strip()}
 
+def extract_ipc_prefix(ipc_str):
+    """
+    IPCコードからプレフィックスを抽出する
+    例: "B41J 2/055 20060101AFI20131004BHJP" -> "B41J2"
+    例: "C07H 5/06" -> "C07H5"
+    """
+    s = ipc_str.strip().upper()
+    # "/"で分割して前半部分を取得
+    if "/" in s:
+        s = s.split("/", 1)[0]
+    # 空白を除去して正規化
+    s = re.sub(r"\s+", "", s)
+    # 最初の5文字を取得（セクション+クラス+サブクラス）
+    # 例: B41J2, C07H5, A61P3
+    if len(s) >= 5:
+        return s[:5]
+    elif len(s) >= 4:
+        return s[:4]
+    return s if s else None
+
+def extract_ipc_prefixes(classification_ipc):
+    """
+    classification_ipcリストからipc_prefixリストを生成する
+    """
+    prefixes = []
+    for ipc_entry in classification_ipc:
+        raw = ipc_entry.get('raw', '') if isinstance(ipc_entry, dict) else str(ipc_entry)
+        prefix = extract_ipc_prefix(raw)
+        if prefix and prefix not in prefixes:
+            prefixes.append(prefix)
+    return prefixes
+
 def parse_patent_xml(xml_path):
     with open(xml_path, 'r', encoding='utf-8') as f:
         xml_content = f.read()
@@ -107,6 +139,9 @@ def parse_new_format(root, xml_path, xml_content):
     raw_ipc = get_all_texts(biblio, './/pat:MainClassification', namespaces=NAMESPACES) + get_all_texts(biblio, './/pat:FurtherClassification', namespaces=NAMESPACES)
     classification_ipc = [parse_ipc_entry(ipc) for ipc in raw_ipc]
 
+    # IPCプレフィックスを抽出（検索用）
+    ipc_prefix = extract_ipc_prefixes(classification_ipc)
+
     # キーワード抽出
     keywords = extract_keywords_keybert_fasttext(summary, topn=10) if summary else []
     topics = extract_topics({'metadata': {'classification_ipc': classification_ipc, 'keywords': keywords}})
@@ -144,6 +179,7 @@ def parse_new_format(root, xml_path, xml_content):
             'publication_date': publication_date,
             'reference': reference_obj,
             'classification_ipc': classification_ipc,
+            'ipc_prefix': ipc_prefix,
             'classification_fi': classification_national,
             'f_term': f_term,
             'theme_code': theme_code,
@@ -214,6 +250,9 @@ def parse_old_format(root, xml_path, xml_content):
     raw_ipc = get_all_texts(biblio, './classification-ipc/main-clsf') + get_all_texts(biblio, './classification-ipc/further-clsf')
     classification_ipc = [parse_ipc_entry(ipc) for ipc in raw_ipc]
 
+    # IPCプレフィックスを抽出（検索用）
+    ipc_prefix = extract_ipc_prefixes(classification_ipc)
+
     # キーワード抽出
     keywords = extract_keywords_keybert_fasttext(summary, topn=10) if summary else []
     topics = extract_topics({'metadata': {'classification_ipc': classification_ipc, 'keywords': keywords}})
@@ -251,6 +290,7 @@ def parse_old_format(root, xml_path, xml_content):
             'publication_date': publication_date,
             'reference': reference_obj,
             'classification_ipc': classification_ipc,
+            'ipc_prefix': ipc_prefix,
             'classification_fi': classification_national,
             'f_term': f_term,
             'theme_code': theme_code,

--- a/prod-search-patent/services/api/app/models.py
+++ b/prod-search-patent/services/api/app/models.py
@@ -41,3 +41,10 @@ class JobCancelResponse(BaseModel):
     job_id: str
     status: str
     queue_entries_removed: int = Field(0, description="Number of queued tasks removed")
+
+
+class KeywordSearchResultResponse(BaseModel):
+    job_id: str
+    patent_ids: List[str] = Field(default_factory=list)
+    pipeline_stats: Dict[str, Any] = Field(default_factory=dict)
+    total_count: int = 0

--- a/prod-search-patent/services/api/app/routes.py
+++ b/prod-search-patent/services/api/app/routes.py
@@ -1,18 +1,25 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from typing import Any, Dict
 
 import httpx
+from azure.cosmos import CosmosClient
 from elasticsearch import Elasticsearch
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from neo4j import GraphDatabase
+from pydantic import BaseModel
 
 from pipeline import IngestionError, JobManager, PipelineConfig
 from pipeline.job_manager import JobState
 
-from .models import GraphResult, IngestResponse, JobCancelResponse, JobStatusResponse, PipelineResultResponse
+from .models import GraphResult, IngestResponse, JobCancelResponse, JobStatusResponse, PipelineResultResponse, KeywordSearchResultResponse
 from .deps import get_job_manager, get_pipeline_config
+
+
+class PatentNumberRequest(BaseModel):
+    patent_number: str
 
 router = APIRouter()
 
@@ -75,6 +82,51 @@ async def ingest_patent_text(
     return IngestResponse(job_id=job_id, status_url=status_url, result_url=result_url, detail=initial_detail)
 
 
+@router.post("/ingest-by-patent-number", response_model=IngestResponse, status_code=202)
+async def ingest_by_patent_number(
+    request: Request,
+    body: PatentNumberRequest,
+    job_manager: JobManager = Depends(get_job_manager),
+    config: PipelineConfig = Depends(get_pipeline_config),
+) -> IngestResponse:
+    """テスト用: 特許番号からCosmosDBのJSONを取得してジョブを作成"""
+    patent_number = body.patent_number.strip()
+
+    # 特許番号から数字部分を抽出 (JP2024001234A -> 2024001234)
+    import re
+    doc_number = re.sub(r'[^0-9]', '', patent_number)
+    if not doc_number:
+        raise HTTPException(status_code=400, detail="Invalid patent number format")
+
+    # CosmosDBから特許データを取得
+    try:
+        cosmos_client = CosmosClient(config.cosmos_endpoint, config.cosmos_key)
+        database = cosmos_client.get_database_client(config.cosmos_database)
+        container = database.get_container_client(config.cosmos_container)
+
+        query = f"SELECT * FROM c WHERE c.bibliographic.publication.doc_number = '{doc_number}'"
+        items = list(container.query_items(query=query, enable_cross_partition_query=True))
+
+        if not items:
+            raise HTTPException(status_code=404, detail=f"Patent {patent_number} not found in CosmosDB")
+
+        patent_json = items[0]
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"CosmosDB error: {str(e)}")
+
+    # JSONをペイロードとして保存
+    initial_detail = _initial_job_detail()
+    job_id = job_manager.create_job(JobState(status="queued", detail=initial_detail))
+    job_manager.store_payload(job_id, {"json": json.dumps(patent_json, ensure_ascii=False)})
+    job_manager.enqueue_job(job_id)
+
+    status_url = str(request.url_for("get_job_status", job_id=job_id))
+    result_url = str(request.url_for("get_job_result", job_id=job_id))
+    return IngestResponse(job_id=job_id, status_url=status_url, result_url=result_url, detail=initial_detail)
+
+
 @router.get("/status/{job_id}", name="get_job_status", response_model=JobStatusResponse)
 def get_status(job_id: str, job_manager: JobManager = Depends(get_job_manager)) -> JobStatusResponse:
     state = job_manager.get_state(job_id)
@@ -112,6 +164,28 @@ def cancel_job(job_id: str, job_manager: JobManager = Depends(get_job_manager)) 
 
     removed = job_manager.cancel_job(job_id, reason="ユーザー操作によりキャンセルされました")
     return JobCancelResponse(job_id=job_id, status="cancelled", queue_entries_removed=removed)
+
+
+@router.get("/keyword-search-result/{job_id}", response_model=KeywordSearchResultResponse)
+def get_keyword_search_result(job_id: str, job_manager: JobManager = Depends(get_job_manager)) -> KeywordSearchResultResponse:
+    """キーワード検索結果（10,000件の特許番号リスト）を取得"""
+    state = job_manager.get_state(job_id)
+    if not state:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    result_payload = job_manager.fetch_result(job_id)
+    if not result_payload:
+        raise HTTPException(status_code=404, detail="Keyword search result not available")
+
+    patent_ids = result_payload.get("keyword_search_results", [])
+    pipeline_stats = result_payload.get("pipeline_stats", {})
+
+    return KeywordSearchResultResponse(
+        job_id=job_id,
+        patent_ids=patent_ids,
+        pipeline_stats=pipeline_stats,
+        total_count=len(patent_ids)
+    )
 
 
 @router.get("/healthz")

--- a/prod-search-patent/services/api/requirements.txt
+++ b/prod-search-patent/services/api/requirements.txt
@@ -8,3 +8,5 @@ openai==1.35.10
 pydantic-settings==2.3.4
 python-dotenv==1.0.1
 azure-cosmos==4.7.0
+beautifulsoup4==4.12.3
+requests==2.31.0

--- a/prod-search-patent/services/frontend/src/components/PatentInput.tsx
+++ b/prod-search-patent/services/frontend/src/components/PatentInput.tsx
@@ -1,6 +1,15 @@
 // frontend/src/components/PatentInput.tsx
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Upload, FileText, Plus, Trash2, Send, ExternalLink, FileText as FileIcon } from "lucide-react";
+import {
+  Upload,
+  FileText,
+  Plus,
+  Trash2,
+  Send,
+  ExternalLink,
+  FileText as FileIcon,
+  X,
+} from "lucide-react";
 import "./PatentInput.css";
 import StageProgress from "./StageProgress";
 import { StageDetail } from "../types";
@@ -15,15 +24,26 @@ const POLL_INTERVAL_MS = 3000;
 
 const STAGES = [
   { id: "parsing", label: "① テキスト解析" },
-  { id: "cosmos_query", label: "② Cosmos検索" },
-  { id: "trimming", label: "③ トリミング" },
-  { id: "embedding", label: "④ 埋め込み生成" },
-  { id: "stage1_indexing", label: "⑤ Stage1インデックス" },
-  { id: "vector_search", label: "⑥ ベクトル検索" },
-  { id: "stage2_indexing", label: "⑦ Neo4j登録" },
-  { id: "graph_rag", label: "⑧ Graph-RAG" },
-  { id: "analysis", label: "⑨ 特許分析" },
+  { id: "keyword_search", label: "② キーワード検索" },
+  { id: "embedding", label: "③ 埋め込み生成" },
+  { id: "stage1_indexing", label: "④ Stage1インデックス" },
+  { id: "vector_search", label: "⑤ ベクトル検索" },
+  { id: "stage2_indexing", label: "⑥ Neo4j登録" },
+  { id: "graph_rag", label: "⑦ Graph-RAG" },
+  { id: "analysis", label: "⑧ 特許分析" },
 ];
+
+// ステージIDを日本語ラベルに変換
+const STAGE_LABELS: Record<string, string> = {
+  parsing: "① テキスト解析",
+  keyword_search: "② キーワード検索",
+  embedding: "③ 埋め込み生成",
+  stage1_indexing: "④ Stage1インデックス",
+  vector_search: "⑤ ベクトル検索",
+  stage2_indexing: "⑥ Neo4j登録",
+  graph_rag: "⑦ Graph-RAG",
+  analysis: "⑧ 特許分析",
+};
 
 interface PatentSlot {
   id: string;
@@ -89,10 +109,92 @@ const PatentInput: React.FC = () => {
   const [jobs, setJobs] = useState<JobInfo[]>([]);
   const jobsRef = useRef<JobInfo[]>([]);
 
+  // キーワード検索結果モーダル用state
+  const [showPatentListModal, setShowPatentListModal] = useState(false);
+  const [patentListData, setPatentListData] = useState<{
+    jobId: string;
+    patentIds: string[];
+    totalCount: number;
+    pipelineStats: Record<string, unknown>;
+  } | null>(null);
+
+  // テスト用: 特許番号入力
+  const [testPatentNumber, setTestPatentNumber] = useState("");
+  const [testLoading, setTestLoading] = useState(false);
+
+  // キーワード検索結果を取得してモーダルを表示
+  const handleShowPatentList = async (jobId: string) => {
+    try {
+      const res = await fetch(`${API_BASE}/keyword-search-result/${jobId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setPatentListData({
+          jobId: data.job_id,
+          patentIds: data.patent_ids,
+          totalCount: data.total_count,
+          pipelineStats: data.pipeline_stats,
+        });
+        setShowPatentListModal(true);
+      } else {
+        alert("キーワード検索結果の取得に失敗しました");
+      }
+    } catch (err) {
+      console.error("Failed to fetch keyword search result", err);
+      alert("キーワード検索結果の取得に失敗しました");
+    }
+  };
+
+  // テスト用: 特許番号から分析を実行
+  const handleTestAnalysis = async () => {
+    if (!testPatentNumber.trim()) {
+      alert("特許番号を入力してください");
+      return;
+    }
+
+    setTestLoading(true);
+    try {
+      const response = await fetch(`${API_BASE}/ingest-by-patent-number`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ patent_number: testPatentNumber.trim() }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        alert(payload.detail ?? "ジョブ投入に失敗しました");
+        return;
+      }
+
+      const payload = await response.json();
+      const newJob: JobInfo = {
+        slotId: `test_${Date.now()}`,
+        jobId: payload.job_id,
+        fileName: `${testPatentNumber.trim()}.json`,
+        status: "queued",
+        detail: payload.detail ?? {},
+        pollActive: true,
+      };
+
+      setJobs((prev: JobInfo[]) => [newJob, ...prev]);
+      setTestPatentNumber("");
+      alert(`ジョブを受け付けました: ${testPatentNumber}`);
+    } catch (error) {
+      console.error("Error:", error);
+      alert("エラーが発生しました");
+    } finally {
+      setTestLoading(false);
+    }
+  };
+
   // 特許を追加（最大5件）
   const addPatent = () => {
     if (patents.length < 5) {
-      setPatents([...patents, { id: `patent_${patents.length + 1}`, file: null }]);
+      setPatents([
+        ...patents,
+        { id: `patent_${patents.length + 1}`, file: null },
+      ]);
     }
   };
 
@@ -120,7 +222,9 @@ const PatentInput: React.FC = () => {
       const results = await Promise.all(
         jobIds.map(async (jobId) => {
           try {
-            const res = await fetch(`${API_BASE}/cancel/${jobId}`, { method: "POST" });
+            const res = await fetch(`${API_BASE}/cancel/${jobId}`, {
+              method: "POST",
+            });
             if (!res.ok) {
               console.error("Failed to cancel job", jobId, await res.text());
               return false;
@@ -133,7 +237,9 @@ const PatentInput: React.FC = () => {
         })
       );
       if (results.some((ok) => !ok)) {
-        alert("一部のジョブのキャンセルに失敗しました。数秒後に再度ご確認ください。");
+        alert(
+          "一部のジョブのキャンセルに失敗しました。数秒後に再度ご確認ください。"
+        );
       }
     }
     setPatents([{ id: "patent_1", file: null }]);
@@ -167,7 +273,9 @@ const PatentInput: React.FC = () => {
 
         if (!response.ok) {
           const payload = await response.json().catch(() => ({}));
-          alert(`${slot.file.name}: ${payload.detail ?? "ジョブ投入に失敗しました"}`);
+          alert(
+            `${slot.file.name}: ${payload.detail ?? "ジョブ投入に失敗しました"}`
+          );
           continue;
         }
 
@@ -184,7 +292,9 @@ const PatentInput: React.FC = () => {
 
       if (newJobs.length > 0) {
         setJobs((prev) => [...newJobs, ...prev]);
-        alert(`${newJobs.length} 件のジョブを受け付けました。進捗は下部カードで確認できます。`);
+        alert(
+          `${newJobs.length} 件のジョブを受け付けました。進捗は下部カードで確認できます。`
+        );
       }
     } catch (error) {
       console.error("Error:", error);
@@ -200,7 +310,10 @@ const PatentInput: React.FC = () => {
       try {
         const res = await fetch(`${API_BASE}/status/${job.jobId}`);
         if (res.status === 404) {
-          updates[job.jobId] = { pollActive: false, error: "ジョブが見つかりません" };
+          updates[job.jobId] = {
+            pollActive: false,
+            error: "ジョブが見つかりません",
+          };
           continue;
         }
         const payload = await res.json();
@@ -214,7 +327,7 @@ const PatentInput: React.FC = () => {
         const baseUpdate: Partial<JobInfo> = {
           status: payload.status,
           detail: payload.detail,
-          candidateCount: detail?.candidate_count ?? job.candidateCount,
+          candidateCount: detail?.narrowed_count ?? job.candidateCount,
           error: errorMessage,
         };
 
@@ -228,6 +341,10 @@ const PatentInput: React.FC = () => {
             const resultPayload = await resultRes.json();
             baseUpdate.resultPayload = resultPayload;
             baseUpdate.pollActive = false;
+            // 完了済みジョブでもcandidateCountを設定（pipeline_statsから取得）
+            if (!baseUpdate.candidateCount && resultPayload.pipeline_stats) {
+              baseUpdate.candidateCount = resultPayload.pipeline_stats.stage2_keyword_filter_results;
+            }
           } else if (resultRes.status === 202) {
             baseUpdate.pollActive = true;
           } else {
@@ -245,7 +362,9 @@ const PatentInput: React.FC = () => {
 
     if (Object.keys(updates).length > 0) {
       setJobs((prev) =>
-        prev.map((item) => (updates[item.jobId] ? { ...item, ...updates[item.jobId] } : item))
+        prev.map((item) =>
+          updates[item.jobId] ? { ...item, ...updates[item.jobId] } : item
+        )
       );
     }
   };
@@ -269,7 +388,11 @@ const PatentInput: React.FC = () => {
         if (res.status === 200) {
           const payload = await res.json();
           setJobs((prev) =>
-            prev.map((item) => (item.jobId === job.jobId ? { ...item, resultPayload: payload } : item))
+            prev.map((item) =>
+              item.jobId === job.jobId
+                ? { ...item, resultPayload: payload }
+                : item
+            )
           );
           launchResultView(payload);
         }
@@ -286,7 +409,9 @@ const PatentInput: React.FC = () => {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (!stored) return;
     try {
-      const parsed = JSON.parse(stored) as { jobs?: Array<{ slotId: string; jobId: string; fileName: string }> };
+      const parsed = JSON.parse(stored) as {
+        jobs?: Array<{ slotId: string; jobId: string; fileName: string }>;
+      };
       if (parsed.jobs && Array.isArray(parsed.jobs) && parsed.jobs.length > 0) {
         const restored = parsed.jobs.map<JobInfo>((meta) => ({
           slotId: meta.slotId,
@@ -327,22 +452,25 @@ const PatentInput: React.FC = () => {
     return `${active} 実行中・${completed} 完了`;
   }, [jobs]);
 
-  const isResultReady = (job: JobInfo) => job.status === "completed" && Boolean(job.resultPayload);
+  const isResultReady = (job: JobInfo) =>
+    job.status === "completed" && Boolean(job.resultPayload);
 
   return (
     <div className="patent-input-container">
       <div className="header-section">
         <h1>特許分析システム</h1>
-        <p className="subtitle">JSONファイルをアップロードして特許の新規性・進歩性を分析します</p>
+        <p className="subtitle">
+          XMLファイルをアップロードして特許の新規性・進歩性を分析します
+        </p>
       </div>
-      
+
       {/* 出願特許の入力 */}
       <div className="patents-section">
         <h3>
           <FileText size={24} />
           出願特許（最大5件）
         </h3>
-        
+
         {patents.map((patent, index) => (
           <div key={patent.id} className="patent-input-item">
             <div className="patent-header">
@@ -357,16 +485,21 @@ const PatentInput: React.FC = () => {
                 </button>
               )}
             </div>
-            
+
             <div className="patent-content">
               <div className="file-upload-area">
                 <input
                   type="file"
                   accept=".txt"
-                  onChange={(e) => e.target.files && handleFileUpload(index, e.target.files[0])}
+                  onChange={(e) =>
+                    e.target.files && handleFileUpload(index, e.target.files[0])
+                  }
                   id={`patent-file-${index}`}
                 />
-                <label htmlFor={`patent-file-${index}`} className="file-upload-label">
+                <label
+                  htmlFor={`patent-file-${index}`}
+                  className="file-upload-label"
+                >
                   <Upload size={20} />
                   <span>.txt（XML）ファイルをアップロード</span>
                 </label>
@@ -380,7 +513,7 @@ const PatentInput: React.FC = () => {
             </div>
           </div>
         ))}
-        
+
         {patents.length < 5 && (
           <button className="add-patent-btn" onClick={addPatent}>
             <Plus size={20} />
@@ -392,7 +525,11 @@ const PatentInput: React.FC = () => {
       {/* 分析実行ボタン */}
       <div className="action-section">
         <div className="action-buttons">
-          <button className="reset-btn" onClick={resetAll} disabled={isLoading && patents.every((p) => !p.file)}>
+          <button
+            className="reset-btn"
+            onClick={resetAll}
+            disabled={isLoading && patents.every((p) => !p.file)}
+          >
             リセット
           </button>
           <button
@@ -415,6 +552,66 @@ const PatentInput: React.FC = () => {
         </div>
       </div>
 
+      {/* テスト用: 特許番号入力 */}
+      <div
+        className="test-section"
+        style={{
+          marginTop: "24px",
+          padding: "16px",
+          backgroundColor: "#fef3c7",
+          borderRadius: "8px",
+          border: "1px solid #f59e0b",
+        }}
+      >
+        <h4
+          style={{ margin: "0 0 12px 0", color: "#92400e", fontSize: "14px" }}
+        >
+          テスト用（後ほど削除）:
+          特許番号から分析(cosmosDBに保存されているjsonファイルを利用)
+        </h4>
+        <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+          <input
+            type="text"
+            placeholder="例: JP2024001234A または 2024001234"
+            value={testPatentNumber}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setTestPatentNumber(e.target.value)
+            }
+            style={{
+              flex: 1,
+              padding: "8px 12px",
+              borderRadius: "4px",
+              border: "1px solid #d1d5db",
+              fontSize: "14px",
+            }}
+            onKeyDown={(e: React.KeyboardEvent) => {
+              if (e.key === "Enter" && !testLoading) {
+                handleTestAnalysis();
+              }
+            }}
+          />
+          <button
+            onClick={handleTestAnalysis}
+            disabled={testLoading || !testPatentNumber.trim()}
+            style={{
+              padding: "8px 16px",
+              backgroundColor:
+                testLoading || !testPatentNumber.trim() ? "#d1d5db" : "#f59e0b",
+              color: "white",
+              border: "none",
+              borderRadius: "4px",
+              cursor:
+                testLoading || !testPatentNumber.trim()
+                  ? "not-allowed"
+                  : "pointer",
+              fontSize: "14px",
+            }}
+          >
+            {testLoading ? "処理中..." : "テスト実行"}
+          </button>
+        </div>
+      </div>
+
       {jobs.length > 0 && (
         <section className="job-section">
           <div className="job-section__header">
@@ -432,20 +629,30 @@ const PatentInput: React.FC = () => {
                       <small>ID: {job.jobId}</small>
                     </div>
                   </div>
-                  <span className={statusBadgeClass(job.status)}>{job.status}</span>
+                  <span className={statusBadgeClass(job.status)}>
+                    {job.status}
+                  </span>
                 </header>
-                <StageProgress stages={STAGES} detail={job.detail} />
+                <StageProgress
+                  stages={STAGES}
+                  detail={job.detail}
+                  onShowPatentList={() => handleShowPatentList(job.jobId)}
+                  keywordSearchCount={job.candidateCount}
+                />
                 <div className="job-meta">
                   {job.candidateCount !== undefined && (
                     <div>
-                      <span>Cosmos 戻り件数</span>
+                      <span>現在の絞り込み件数</span>
                       <strong>{job.candidateCount.toLocaleString()} 件</strong>
                     </div>
                   )}
                   {job.detail?.current_stage && (
                     <div>
                       <span>現在ステージ</span>
-                      <strong>{job.detail.current_stage}</strong>
+                      <strong>
+                        {STAGE_LABELS[job.detail.current_stage] ||
+                          job.detail.current_stage}
+                      </strong>
                     </div>
                   )}
                 </div>
@@ -472,6 +679,142 @@ const PatentInput: React.FC = () => {
             ))}
           </div>
         </section>
+      )}
+
+      {/* キーワード検索結果モーダル */}
+      {showPatentListModal && patentListData && (
+        <div
+          className="modal-overlay"
+          onClick={() => setShowPatentListModal(false)}
+          style={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: "rgba(0, 0, 0, 0.5)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 1000,
+          }}
+        >
+          <div
+            className="modal-content"
+            onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            style={{
+              backgroundColor: "white",
+              borderRadius: "8px",
+              padding: "24px",
+              maxWidth: "600px",
+              width: "90%",
+              maxHeight: "80vh",
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                marginBottom: "16px",
+              }}
+            >
+              <h3 style={{ margin: 0, fontSize: "18px" }}>
+                キーワード検索結果 ({patentListData.totalCount.toLocaleString()}
+                件)
+              </h3>
+              <button
+                onClick={() => setShowPatentListModal(false)}
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  padding: "4px",
+                }}
+              >
+                <X size={20} />
+              </button>
+            </div>
+            <div
+              style={{ marginBottom: "12px", fontSize: "12px", color: "#666" }}
+            >
+              <p style={{ margin: "4px 0" }}>
+                STAGE1 IPC候補:{" "}
+                {(
+                  patentListData.pipelineStats.stage1_IPC_candidates as number
+                )?.toLocaleString() ?? "-"}
+                件
+              </p>
+              <p style={{ margin: "4px 0" }}>
+                STAGE2 キーワード絞込:{" "}
+                {(
+                  patentListData.pipelineStats
+                    .stage2_keyword_filter_results as number
+                )?.toLocaleString() ?? "-"}
+                件
+              </p>
+            </div>
+            <div
+              style={{
+                flex: 1,
+                overflowY: "auto",
+                border: "1px solid #e5e7eb",
+                borderRadius: "4px",
+                padding: "8px",
+                fontFamily: "monospace",
+                fontSize: "12px",
+              }}
+            >
+              <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                <thead>
+                  <tr
+                    style={{
+                      position: "sticky",
+                      top: 0,
+                      backgroundColor: "#f9fafb",
+                    }}
+                  >
+                    <th
+                      style={{
+                        padding: "8px 4px",
+                        textAlign: "left",
+                        borderBottom: "1px solid #e5e7eb",
+                      }}
+                    >
+                      順位
+                    </th>
+                    <th
+                      style={{
+                        padding: "8px 4px",
+                        textAlign: "left",
+                        borderBottom: "1px solid #e5e7eb",
+                      }}
+                    >
+                      特許番号
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {patentListData.patentIds.map(
+                    (patentId: string, index: number) => (
+                      <tr
+                        key={patentId}
+                        style={{ borderBottom: "1px solid #f3f4f6" }}
+                      >
+                        <td style={{ padding: "4px", color: "#6b7280" }}>
+                          {index + 1}
+                        </td>
+                        <td style={{ padding: "4px" }}>JP{patentId}A</td>
+                      </tr>
+                    )
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/prod-search-patent/services/frontend/src/components/StageProgress.tsx
+++ b/prod-search-patent/services/frontend/src/components/StageProgress.tsx
@@ -10,7 +10,10 @@ interface StageProgressProps {
   detail?: {
     current_stage?: string;
     stages?: Record<string, Record<string, string>>;
+    narrowed_count?: number;
   };
+  onShowPatentList?: () => void;
+  keywordSearchCount?: number;
 }
 
 const statusColor = (status: StageStatus) => {
@@ -36,7 +39,18 @@ const resolveStatus = (
   return "pending";
 };
 
-const StageProgress = ({ stages, detail }: StageProgressProps) => {
+const getStatusText = (status: StageStatus): string => {
+  switch (status) {
+    case "completed":
+      return "完了";
+    case "in_progress":
+      return "実行中";
+    default:
+      return "待機中";
+  }
+};
+
+const StageProgress = ({ stages, detail, onShowPatentList, keywordSearchCount }: StageProgressProps) => {
   const completedCount = stages.filter(
     (stage) => resolveStatus(stage.id, detail) === "completed"
   ).length;
@@ -59,14 +73,34 @@ const StageProgress = ({ stages, detail }: StageProgressProps) => {
           const className = ["stage-item", statusColor(status)]
             .filter(Boolean)
             .join(" ");
+          const statusText = getStatusText(status);
+
+          // キーワード検索完了時に件数リンクを表示（ジョブ完了後も表示）
+          const isKeywordSearchCompleted = stage.id === "keyword_search" && status === "completed";
+          const narrowedCount = keywordSearchCount ?? detail?.narrowed_count;
+
           return (
             <div key={stage.id} className={className}>
-              <strong>{stage.label}</strong>
-              <small>
-                {status === "completed" && "完了"}
-                {status === "in_progress" && "実行中"}
-                {status === "pending" && "待機中"}
-              </small>
+              <span>
+                {stage.label}{statusText}
+                {isKeywordSearchCompleted && narrowedCount !== undefined && onShowPatentList && (
+                  <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      onShowPatentList();
+                    }}
+                    style={{
+                      marginLeft: "8px",
+                      color: "#2563eb",
+                      textDecoration: "underline",
+                      fontSize: "12px",
+                    }}
+                  >
+                    ({narrowedCount.toLocaleString()}件)
+                  </a>
+                )}
+              </span>
             </div>
           );
         })}

--- a/prod-search-patent/services/frontend/src/types.ts
+++ b/prod-search-patent/services/frontend/src/types.ts
@@ -51,5 +51,6 @@ export type StageDetail = {
   stages?: Record<string, Record<string, string>>;
   completed_stages?: string[];
   candidate_count?: number;
+  narrowed_count?: number;
   [key: string]: unknown;
 };

--- a/prod-search-patent/services/worker/requirements.txt
+++ b/prod-search-patent/services/worker/requirements.txt
@@ -5,3 +5,6 @@ httpx==0.27.0
 openai==1.35.10
 watchfiles==0.21.0
 azure-cosmos==4.7.0
+beautifulsoup4==4.12.3
+requests==2.31.0
+python-dotenv==1.0.1

--- a/prod-search-patent/services/worker/worker.py
+++ b/prod-search-patent/services/worker/worker.py
@@ -10,6 +10,7 @@ from pipeline import (
     PipelineConfig,
     JobState,
     run_pipeline,
+    run_patent_search_from_json,
 )
 
 logging.basicConfig(
@@ -17,6 +18,10 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
 )
 logger = logging.getLogger("worker")
+
+# Azure SDKのログを抑制（リクエスト/レスポンスヘッダーを非表示）
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
+logging.getLogger("azure.cosmos").setLevel(logging.WARNING)
 
 config = PipelineConfig()
 job_manager = JobManager(config.redis_url)
@@ -52,7 +57,10 @@ async def process_job(job_id: str) -> None:
     job_manager.set_state(job_id, JobState(status="processing", detail=state.detail if state else {}))
 
     try:
-        await run_pipeline(config, job_manager, job_id, input_bytes)
+        # Run the full pipeline (parsing, cosmos query, keyword search, embedding, etc.)
+        pipeline_result = await run_pipeline(config, job_manager, job_id, input_bytes)
+        logger.info("Job %s: Pipeline completed successfully", job_id)
+
     except JobCancelledError:
         logger.info("Job %s cancelled during processing", job_id)
     except IngestionError as exc:

--- a/prod-search-patent/src/pipeline/__init__.py
+++ b/prod-search-patent/src/pipeline/__init__.py
@@ -4,6 +4,7 @@ from .config import PipelineConfig
 from .pipeline_runner import run_pipeline
 from .job_manager import JobManager, JobState
 from .exceptions import IngestionError, JobCancelledError
+from .patent_search_pipeline import run_patent_search_from_json
 
 __all__ = [
     "PipelineConfig",
@@ -12,4 +13,5 @@ __all__ = [
     "JobState",
     "IngestionError",
     "JobCancelledError",
+    "run_patent_search_from_json",
 ]

--- a/prod-search-patent/src/pipeline/abc_keyword_extractor_v3.py
+++ b/prod-search-patent/src/pipeline/abc_keyword_extractor_v3.py
@@ -1,0 +1,281 @@
+import os
+import csv
+import re
+from datetime import datetime
+from dotenv import load_dotenv
+from azure.cosmos import CosmosClient
+from openai import AzureOpenAI
+
+"""
+ABC キーワード抽出 v3
+- Aカテゴリは省略
+- B・Cカテゴリに優先順位（MUST/SHOULD）を付与
+- キーワードは最小単位に分解
+- 類似語も含める
+- Azure OpenAI gpt-5-mini を使用（フォールバック: gpt-4o）
+"""
+
+load_dotenv()
+
+# Azure OpenAI クライアント (gpt-5-mini用)
+client = AzureOpenAI(
+    api_version=os.environ.get("API_VERSION"),
+    azure_endpoint=os.environ.get("ENDPOINT"),
+    api_key=os.environ.get("API_KEY"),
+)
+
+# Azure OpenAI クライアント (gpt-4o用 - フォールバック)
+client_4o = AzureOpenAI(
+    api_version=os.environ.get("API_VERSION_4o"),
+    azure_endpoint=os.environ.get("ENDPOINT_4o"),
+    api_key=os.environ.get("API_KEY_4o"),
+)
+
+def extract_keywords_with_priority(title, abstract, claims_texts):
+    """LLMを使用してB・Cカテゴリキーワードを優先順位付きで抽出"""
+    
+    prompt = f"""
+# タスク
+以下の特許文書から、発明の核心となるキーワードを抽出してください。
+AカテゴリーはスキップしてBとCのみ抽出します。
+
+## Bカテゴリ（構成/作用）
+発明の中核となる構成要素、材料、または主要な作用・プロセスを示すキーワード。
+
+### 抽出ルール
+1. **優先順位**:
+   - MUST: 発明に絶対不可欠な要素（この要素がないと発明が成立しない）
+   - SHOULD: 重要だが必須ではない要素（発明の特徴を示すが代替可能）
+
+2. **分解**: 複合語は最小単位の名詞に分解すること
+   - 例: 「変化表示」→「変化」+「表示」
+   - 例: 「乱数取得手段」→「乱数」+「取得」+「手段」
+   
+3. **類似語**: 各キーワードに対して、特許検索で使える類似語を3-5個程度含める
+   - 例: 「表示」→「表示」「ディスプレイ」「画面」「表出」
+   - 例: 「制御」→「制御」「コントロール」「管理」「調整」
+
+## Cカテゴリ（特徴/差別化）
+発明の新規性や進歩性を示す、従来技術との差別化ポイント。
+
+### 抽出ルール
+1. **優先順位**:
+   - MUST: 発明の最も重要な差別化要素（課題解決の核心）
+   - SHOULD: 補助的な特徴や効果
+
+2. **分解**: 複合語は最小単位に分解
+   - 例: 「先読み演出」→「先読み」+「演出」
+   
+3. **類似語**: 類義語・関連語を含める
+   - 例: 「先読み」→「先読み」「予測」「事前判定」「予告」
+
+## 抽出ヒント
+- 「〜を含む」「〜からなる」の後のキーワードはBカテゴリ
+- 「〜を特徴とする」「〜に優れる」「〜ができる」の前のキーワードはCカテゴリ
+- 化学品系なら化合物名・化学物質名はBカテゴリのMUST
+- 【課題】【解決手段】に記載の内容は特に重要
+
+# 特許インプット
+タイトル: {title}
+要約: {abstract}
+""" + "\n".join([f"請求項{i+1}: {ct[:500]}" for i, ct in enumerate(claims_texts[:3])]) + """
+
+# 出力フォーマット（JSON形式）
+```json
+{{
+  "B_MUST": [
+    {{
+      "base_keyword": "基本キーワード（分解後）",
+      "synonyms": ["類似語1", "類似語2", "類似語3"]
+    }}
+  ],
+  "B_SHOULD": [
+    {{
+      "base_keyword": "基本キーワード",
+      "synonyms": ["類似語1", "類似語2"]
+    }}
+  ],
+  "C_MUST": [
+    {{
+      "base_keyword": "基本キーワード",
+      "synonyms": ["類似語1", "類似語2", "類似語3"]
+    }}
+  ],
+  "C_SHOULD": [
+    {{
+      "base_keyword": "基本キーワード",
+      "synonyms": ["類似語1", "類似語2"]
+    }}
+  ]
+}}
+```
+
+重要: JSON形式で出力してください。コードブロックの中にJSONを記述してください。
+"""
+    
+    # Azure OpenAI: gpt-5-mini を優先、失敗時に gpt-4o へフォールバック
+    models = [
+        ("gpt-5-mini", client),
+        ("gpt-4o", client_4o)
+    ]
+
+    for model_name, api_client in models:
+        try:
+            # Azure OpenAI Chat Completions API
+            # Note: gpt-5-mini does not support temperature parameter (only default 1)
+            response = api_client.chat.completions.create(
+                model=model_name,
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant that extracts keywords from patent documents. Please output valid JSON."},
+                    {"role": "user", "content": prompt}
+                ],
+                max_tokens=4096
+            )
+            text = response.choices[0].message.content
+
+            # JSONを抽出
+            import json
+            json_match = re.search(r'```(?:json)?\s*(\{.*?\})\s*```', text, re.DOTALL)
+            if json_match:
+                try:
+                    result = json.loads(json_match.group(1))
+                    if any(result.get(key) for key in ["B_MUST", "B_SHOULD", "C_MUST", "C_SHOULD"]):
+                        return result
+                except json.JSONDecodeError:
+                    pass
+
+            # 空の結果の場合、次のモデルにフォールバック
+            if model_name == "gpt-5-mini":
+                print(f"[INFO] gpt-5-mini returned empty result, falling back to gpt-4o")
+                continue
+
+        except Exception as e:
+            # エラー時は次のモデルを試行
+            if model_name == "gpt-5-mini":
+                print(f"[WARN] gpt-5-mini error: {e}, falling back to gpt-4o")
+                continue
+            else:
+                print(f"[ERROR] gpt-4o error: {e}")
+                pass
+
+    # 全て失敗した場合は空の構造を返す
+    return {
+        "B_MUST": [],
+        "B_SHOULD": [],
+        "C_MUST": [],
+        "C_SHOULD": []
+    }
+
+def format_keywords_for_csv(keywords_dict):
+    """キーワード辞書をCSV出力用にフォーマット"""
+    def format_category(items):
+        parts = []
+        for item in items:
+            base = item.get("base_keyword", "")
+            synonyms = item.get("synonyms", [])
+            if synonyms:
+                parts.append(f"{base}({', '.join(synonyms)})")
+            else:
+                parts.append(base)
+        return " | ".join(parts)
+    
+    return {
+        "B_MUST": format_category(keywords_dict.get("B_MUST", [])),
+        "B_SHOULD": format_category(keywords_dict.get("B_SHOULD", [])),
+        "C_MUST": format_category(keywords_dict.get("C_MUST", [])),
+        "C_SHOULD": format_category(keywords_dict.get("C_SHOULD", []))
+    }
+
+def main():
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="ABC v3: B・Cカテゴリキーワード抽出（優先順位・分解・類似語対応）")
+    parser.add_argument('--limit', type=int, default=1, help='取得件数')
+    parser.add_argument('--doc-numbers', type=str, help='特定の特許番号（カンマ区切り）例: 2017080220,2018143828')
+    args = parser.parse_args()
+    
+    COSMOS_ENDPOINT = os.environ.get("COSMOS_ENDPOINT")
+    COSMOS_KEY = os.environ.get("COSMOS_KEY")
+    DATABASE_NAME = os.environ.get("DATABASE_NAME")
+    CONTAINER_NAME = os.environ.get("CONTAINER_NAME")
+    
+    cosmos_client = CosmosClient(COSMOS_ENDPOINT, COSMOS_KEY)
+    container = cosmos_client.get_database_client(DATABASE_NAME).get_container_client(CONTAINER_NAME)
+    
+    # 特許番号リストの取得
+    doc_numbers = []
+    if args.doc_numbers:
+        doc_numbers = [num.strip() for num in args.doc_numbers.split(',')]
+    else:
+        # syutugan_ax_test_data.csvから取得
+        csv_path = os.path.join(os.path.dirname(__file__), "../data/syutugan_ax_test_data.csv")
+        with open(csv_path, encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for i, row in enumerate(reader):
+                if i >= args.limit:
+                    break
+                syutugan = row.get("syutugan", "").strip()
+                if syutugan:
+                    m = re.match(r"JP(\d+)[A-Z]?", syutugan)
+                    if m:
+                        doc_numbers.append(m.group(1))
+    
+    print(f"処理対象の特許番号: {doc_numbers}")
+    
+    # 特許データを取得して処理
+    results = []
+    for doc_number in doc_numbers:
+        query = "SELECT * FROM c WHERE c.bibliographic.publication.doc_number = @doc_num"
+        params = [{"name": "@doc_num", "value": doc_number}]
+        items = list(container.query_items(query=query, parameters=params, enable_cross_partition_query=True))
+        
+        if not items:
+            print(f"[警告] 特許 {doc_number} が見つかりませんでした")
+            continue
+        
+        doc = items[0]
+        title = doc['bibliographic']['title']
+        abstract = doc.get('abstract', '')
+        claims = doc.get('claims', [])
+        claims_texts = [claim['text'] for claim in claims if isinstance(claim, dict) and 'text' in claim]
+        
+        print(f"\n処理中: {doc_number} - {title}")
+        print(f"  要約文字数: {len(abstract)}, 請求項数: {len(claims_texts)}")
+        
+        # キーワード抽出
+        keywords_dict = extract_keywords_with_priority(title, abstract, claims_texts)
+        formatted = format_keywords_for_csv(keywords_dict)
+        
+        print(f"  B_MUST: {len(keywords_dict.get('B_MUST', []))}件")
+        print(f"  B_SHOULD: {len(keywords_dict.get('B_SHOULD', []))}件")
+        print(f"  C_MUST: {len(keywords_dict.get('C_MUST', []))}件")
+        print(f"  C_SHOULD: {len(keywords_dict.get('C_SHOULD', []))}件")
+        
+        results.append({
+            "patent_id": doc_number,
+            "title": title,
+            "B_MUST": formatted["B_MUST"],
+            "B_SHOULD": formatted["B_SHOULD"],
+            "C_MUST": formatted["C_MUST"],
+            "C_SHOULD": formatted["C_SHOULD"]
+        })
+    
+    # CSV出力
+    outdir = os.path.join(os.path.dirname(__file__), "../data/output_keywords")
+    os.makedirs(outdir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    outfile = os.path.join(outdir, f"abc_v3_keywords_{timestamp}.csv")
+    
+    with open(outfile, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=[
+            "patent_id", "title", "B_MUST", "B_SHOULD", "C_MUST", "C_SHOULD"
+        ])
+        writer.writeheader()
+        for row in results:
+            writer.writerow(row)
+    
+    print(f"\n✓ 結果を保存しました: {outfile}")
+    print(f"✓ 処理件数: {len(results)}/{len(doc_numbers)}")
+
+if __name__ == "__main__":
+    main()

--- a/prod-search-patent/src/pipeline/cosmos_client.py
+++ b/prod-search-patent/src/pipeline/cosmos_client.py
@@ -78,6 +78,7 @@ class CosmosPatentClient:
         if not prefixes:
             raise IngestionError("At least one IPC prefix required", status_code=422)
 
+        logger.info("Cosmos query with IPC prefixes: %s (limit=%d)", prefixes[:10], limit)
         parameters = [{"name": f"@prefix{i}", "value": prefix} for i, prefix in enumerate(prefixes)]
         prefix_conditions = [f"STARTSWITH(ipc.text, @prefix{i}, true)" for i in range(len(prefixes))]
         predicate = " OR ".join(prefix_conditions)

--- a/prod-search-patent/src/pipeline/patent_search_pipeline.py
+++ b/prod-search-patent/src/pipeline/patent_search_pipeline.py
@@ -1,0 +1,627 @@
+#!/usr/bin/env python3
+"""
+特許検索パイプライン
+一件ずつ実行して、類似特許を検索する
+
+使用方法:
+  python scripts/patent_search_pipeline.py JP2021106667A
+  python scripts/patent_search_pipeline.py JP2021106667A --filter-years
+  python scripts/patent_search_pipeline.py JP2021106667A --filter-years --output results.csv
+
+流れ:
+1. 所定のフォルダからsyutugan特許のJSONを取得（なければCosmosDBからダウンロード）
+2. キーワード抽出実行
+3. STAGE1: CosmosDBに対してIPCフィルタリング
+4. STAGE2: キーワードスコアリング
+5. (オプション) 10,000件以上の場合、発行日10年以内で絞り込み
+6. 上位10,000件の特許番号をCSVで出力
+"""
+from azure.cosmos import CosmosClient
+import os
+import json
+import time
+import csv
+import argparse
+import logging
+from datetime import datetime
+from dotenv import load_dotenv
+import sys
+
+# インポートパスを修正（同じディレクトリ内のモジュール）
+from .abc_keyword_extractor_v3 import extract_keywords_with_priority
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# 設定
+INPUT_FOLDER = 'data/input_patents'
+OUTPUT_FOLDER = 'data/output_results'
+
+# グローバル変数（遅延初期化）
+_cosmos_client = None
+_container = None
+
+
+def _get_container():
+    """CosmosDBコンテナを取得（遅延初期化）"""
+    global _cosmos_client, _container
+    if _container is None:
+        _cosmos_client = CosmosClient(
+            os.environ.get('COSMOS_ENDPOINT', ''),
+            os.environ.get('COSMOS_KEY', '')
+        )
+        database = _cosmos_client.get_database_client(
+            os.environ.get('COSMOS_DATABASE', os.environ.get('DATABASE_NAME', 'patent_json'))
+        )
+        _container = database.get_container_client(
+            os.environ.get('COSMOS_CONTAINER', os.environ.get('CONTAINER_NAME', 'patent_json_v2'))
+        )
+    return _container
+
+
+def run_patent_search_from_json(json_payload: dict, job_manager=None, job_id: str = None) -> dict:
+    """
+    JSONペイロードから特許検索パイプラインを実行（worker用）
+
+    Args:
+        json_payload: Redis/APIから受け取ったJSONデータ
+        job_manager: JobManagerインスタンス（進捗更新用）
+        job_id: ジョブID
+
+    Returns:
+        検索結果（patent_idsリストを含む）
+    """
+    start_time = time.time()
+    container = _get_container()
+
+    logger.info("Starting patent search pipeline from JSON payload")
+
+    # JSONからpatentデータを取得
+    if "json" in json_payload:
+        patent = json.loads(json_payload["json"]) if isinstance(json_payload["json"], str) else json_payload["json"]
+    else:
+        patent = json_payload
+
+    # 特許番号取得
+    patent_id = ""
+    if "bibliographic" in patent:
+        doc_number = patent["bibliographic"].get("publication", {}).get("doc_number", "")
+        patent_id = f"JP{doc_number}A" if doc_number else ""
+
+    if not patent_id:
+        patent_id = patent.get("patent_id", "unknown")
+
+    logger.info(f"Target patent: {patent_id}")
+
+    # 特許情報取得
+    title = patent.get('bibliographic', {}).get('invention_title', '')
+    if isinstance(title, dict):
+        title = title.get('ja', '') or title.get('en', '')
+    ipc_list = patent.get('bibliographic', {}).get('classification', {}).get('ipc_prefix', [])
+
+    logger.info(f"Title: {str(title)[:50]}...")
+    logger.info(f"IPC: {ipc_list[:3]}")
+
+    # STEP2: キーワード抽出
+    logger.info("STEP2: Keyword extraction...")
+
+    abstract = patent.get('abstract', '')
+    claims_data = patent.get('claims', [])
+    claims_texts = []
+    if isinstance(claims_data, list):
+        claims_texts = [c.get('claim_text', '') for c in claims_data[:3] if isinstance(c, dict)]
+    elif isinstance(claims_data, dict):
+        claims_list = claims_data.get('claims', [])
+        claims_texts = [c.get('claim_text', '') for c in claims_list[:3] if isinstance(c, dict)]
+
+    keywords = extract_keywords_with_priority(
+        str(title) if title else "",
+        abstract if isinstance(abstract, str) else str(abstract),
+        claims_texts
+    )
+
+    total_keywords = sum(len(keywords.get(cat, [])) for cat in ['B_MUST', 'B_SHOULD', 'C_MUST', 'C_SHOULD'])
+    logger.info(f"Extracted keywords: {total_keywords}")
+
+    # STEP3: STAGE1 IPCフィルタリング
+    logger.info("STEP3: STAGE1 IPC filtering...")
+    candidates = stage1_ipc_filter(patent)
+    logger.info(f"STAGE1 candidates: {len(candidates):,}")
+
+    # STEP4: STAGE2 キーワードスコアリング
+    logger.info("STEP4: STAGE2 keyword scoring...")
+    scored = stage2_keyword_scoring_fast(candidates, keywords, patent, limit=10000)
+    logger.info(f"STAGE2 results: {len(scored):,}")
+
+    elapsed = time.time() - start_time
+
+    # 結果を構成
+    result = {
+        "target_patent": patent_id,
+        "pipeline_stats": {
+            "stage1_IPC_candidates": len(candidates),
+            "stage2_keyword_filter_results": len(scored),
+            "total_keywords": total_keywords,
+            "elapsed_seconds": round(elapsed, 2)
+        },
+        # 後続処理用のpatent_idリスト
+        "keyword_search_results": [doc_num for doc_num, score in scored],
+        "search_results": [{"doc_number": doc_num, "score": score} for doc_num, score in scored],
+        "searched_at": datetime.now().isoformat()
+    }
+
+    # 結果をRedisに保存
+    if job_manager and job_id:
+        job_manager.store_result(job_id, result)
+        logger.info(f"Search result stored for job {job_id}")
+
+    logger.info(f"Search completed in {elapsed:.2f}s, {len(scored)} results")
+
+    return result
+
+
+# 以下は元のコードを維持（container変数を_get_container()に置き換え）
+
+
+def download_patent_from_cosmos(patent_id):
+    """CosmosDBから特許をダウンロードしてJSONとして保存"""
+    container = _get_container()
+    doc_number = ''.join(filter(str.isdigit, patent_id))
+
+    query = f"SELECT * FROM c WHERE c.bibliographic.publication.doc_number = '{doc_number}'"
+    items = list(container.query_items(query=query, enable_cross_partition_query=True))
+
+    if not items:
+        return None
+
+    patent = items[0]
+
+    # フォルダが存在しなければ作成
+    os.makedirs(INPUT_FOLDER, exist_ok=True)
+
+    # JSONとして保存
+    output_path = os.path.join(INPUT_FOLDER, f"{patent_id}.json")
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(patent, f, ensure_ascii=False, indent=2)
+
+    print(f"ダウンロード完了: {output_path}")
+    return patent
+
+
+def load_patent_from_folder(patent_id):
+    """所定のフォルダから特許JSONを読み込む"""
+    json_path = os.path.join(INPUT_FOLDER, f"{patent_id}.json")
+
+    if os.path.exists(json_path):
+        with open(json_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+
+    return None
+
+
+def stage1_ipc_filter(syutugan_patent):
+    """STAGE1: IPCベースのフィルタリング（全候補を取得）"""
+    container = _get_container()
+    ipc_list = syutugan_patent.get('bibliographic', {}).get('classification', {}).get('ipc_prefix', [])
+
+    if not ipc_list:
+        return []
+
+    candidates = set()
+
+    for ipc in ipc_list[:5]:
+        ipc_5 = ipc[:5] if len(ipc) >= 5 else ipc
+
+        query = f"""
+        SELECT c.bibliographic.publication.doc_number
+        FROM c
+        WHERE ARRAY_CONTAINS(c.bibliographic.classification.ipc_prefix, '{ipc_5}')
+           OR EXISTS(SELECT VALUE p FROM p IN c.bibliographic.classification.ipc_prefix WHERE STARTSWITH(p, '{ipc_5}'))
+        """
+
+        items = list(container.query_items(query=query, enable_cross_partition_query=True))
+
+        for item in items:
+            doc_num = item.get('doc_number', '')
+            if doc_num:
+                candidates.add(doc_num)
+
+    return list(candidates)
+
+
+def stage2_keyword_scoring_fast(candidates, keywords, syutugan_patent, batch_size=None, limit=10000):
+    """STAGE2: キーワードベースのスコアリング（バッチクエリで高速化）
+
+    候補数に応じて動的にバッチサイズを調整:
+    - ~10,000件: batch_size=200 (約2分)
+    - 10,000~50,000件: batch_size=500 (約15分)
+    - 50,000~100,000件: batch_size=800 (約40分)
+    - 100,000件~: batch_size=1000 (約90分)
+    """
+    container = _get_container()
+
+    # 候補数に応じた動的バッチサイズ
+    if batch_size is None:
+        num_candidates = len(candidates)
+        if num_candidates <= 10000:
+            batch_size = 200
+        elif num_candidates <= 50000:
+            batch_size = 500
+        elif num_candidates <= 100000:
+            batch_size = 800
+        else:
+            batch_size = 1000
+        print(f"    動的バッチサイズ: {batch_size}件/バッチ", flush=True)
+
+    # 全キーワードをフラットなリストに変換
+    all_keywords = set()
+    for category in ['B_MUST', 'B_SHOULD', 'C_MUST', 'C_SHOULD']:
+        items = keywords.get(category, [])
+        for item in items:
+            base_kw = item.get('base_keyword', '')
+            if base_kw:
+                all_keywords.add(base_kw)
+            for syn in item.get('synonyms', []):
+                if syn:
+                    all_keywords.add(syn)
+
+    # カテゴリ別の重み
+    category_weights = {
+        'B_MUST': 5.0,
+        'B_SHOULD': 3.0,
+        'C_MUST': 2.0,
+        'C_SHOULD': 1.0
+    }
+
+    # キーワードごとの重みを計算
+    keyword_weights = {}
+    for category, weight in category_weights.items():
+        items = keywords.get(category, [])
+        for item in items:
+            base_kw = item.get('base_keyword', '')
+            if base_kw:
+                keyword_weights[base_kw] = weight
+            for syn in item.get('synonyms', []):
+                if syn:
+                    keyword_weights[syn] = weight * 0.8
+
+    # F-ターム取得
+    syutugan_fterms = syutugan_patent.get('bibliographic', {}).get('f_terms', [])
+
+    scored_candidates = []
+
+    # チェックポイント機能
+    checkpoint_file = f'/tmp/checkpoint_{len(candidates)}.json'
+    processed_count = 0
+
+    # 前回のチェックポイントがあれば復元
+    if os.path.exists(checkpoint_file):
+        try:
+            with open(checkpoint_file, 'r', encoding='utf-8') as f:
+                checkpoint_data = json.load(f)
+                scored_candidates = checkpoint_data.get('scored_candidates', [])
+                processed_count = checkpoint_data.get('processed_count', 0)
+                if processed_count > 0:
+                    print(f"    チェックポイント復元: {processed_count}件処理済み", flush=True)
+        except:
+            pass
+
+    # バッチ処理（IN句で複数取得）
+    for batch_idx in range(processed_count, len(candidates), batch_size):
+        batch = candidates[batch_idx:batch_idx+batch_size]
+
+        if batch_idx % 5000 == 0:
+            print(f"    バッチ処理: {batch_idx}/{len(candidates)}件", flush=True)
+
+        # IN句でバッチ取得
+        doc_nums_str = "', '".join(batch)
+        query = f"""
+        SELECT c.bibliographic.publication.doc_number, c.bibliographic.invention_title, c.abstract, c.description, c.claims, c.bibliographic.f_terms
+        FROM c
+        WHERE c.bibliographic.publication.doc_number IN ('{doc_nums_str}')
+        """
+
+        # リトライロジック付きバッチ取得（強化版）
+        max_retries = 5
+        items = []
+        for retry in range(max_retries):
+            try:
+                items = list(container.query_items(query=query, enable_cross_partition_query=True))
+                break
+            except Exception as e:
+                if retry < max_retries - 1:
+                    wait_time = (retry + 1) * 10  # 10秒, 20秒, 30秒, 40秒
+                    print(f"    接続エラー、{wait_time}秒後にリトライ... ({retry + 1}/{max_retries})", flush=True)
+                    time.sleep(wait_time)
+
+                    # クライアント再接続を試みる（3回目のリトライ以降）
+                    if retry >= 2:
+                        print(f"    クライアント再接続を試行...", flush=True)
+                else:
+                    # 最終リトライも失敗した場合は個別に処理
+                    print(f"    バッチ取得失敗、個別処理に切り替え...", flush=True)
+                    for doc_num in batch:
+                        try:
+                            single_query = f"SELECT * FROM c WHERE c.bibliographic.publication.doc_number = '{doc_num}'"
+                            single_items = list(container.query_items(query=single_query, enable_cross_partition_query=True))
+                            if single_items:
+                                candidate = single_items[0]
+                                score = _score_candidate(candidate, keyword_weights, syutugan_fterms, is_gaming_machine)
+                                scored_candidates.append((doc_num, score))
+                        except:
+                            pass  # 個別エラーはスキップ
+                    continue
+
+        for candidate in items:
+            doc_num = candidate.get('doc_number', '')
+            if not doc_num:
+                continue
+
+            score = _score_candidate(candidate, keyword_weights, syutugan_fterms)
+            scored_candidates.append((doc_num, score))
+
+        # チェックポイント保存（5000件ごと）
+        if (batch_idx + batch_size) % 5000 == 0:
+            try:
+                with open(checkpoint_file, 'w', encoding='utf-8') as f:
+                    json.dump({
+                        'scored_candidates': scored_candidates,
+                        'processed_count': batch_idx + batch_size
+                    }, f)
+                print(f"    チェックポイント保存: {batch_idx + batch_size}件", flush=True)
+            except:
+                pass
+
+    # 処理完了後、チェックポイントファイルを削除
+    if os.path.exists(checkpoint_file):
+        try:
+            os.remove(checkpoint_file)
+        except:
+            pass
+
+    # スコアでソート
+    scored_candidates.sort(key=lambda x: x[1], reverse=True)
+
+    # 上位limit件のみを返す
+    return scored_candidates[:limit]
+
+
+def _score_candidate(candidate, keyword_weights, syutugan_fterms, is_gaming_machine=False):
+    """候補のスコアを計算
+
+    Args:
+        candidate: 候補特許データ
+        keyword_weights: キーワード重み辞書
+        syutugan_fterms: 出願特許のF-タームリスト
+        is_gaming_machine: 遊技機(A63F)かどうか
+    """
+    # テキスト準備（dict型対応）
+    text = ""
+
+    # タイトルを検索対象に追加
+    title = candidate.get('bibliographic', {}).get('invention_title', '') or candidate.get('invention_title', '')
+    if title:
+        if isinstance(title, str):
+            text += title + " "
+        elif isinstance(title, dict):
+            text += str(title) + " "
+
+    abstract = candidate.get('abstract', '')
+    if abstract:
+        if isinstance(abstract, str):
+            text += abstract + " "
+        elif isinstance(abstract, dict):
+            text += str(abstract.get('p', '')) + " "
+    if candidate.get('description'):
+        desc = candidate.get('description', '')
+        if isinstance(desc, str):
+            text += desc[:3000] + " "
+        elif isinstance(desc, dict):
+            text += str(desc)[:3000] + " "
+
+    # 請求項1〜5を検索対象に追加
+    claims_data = candidate.get('claims', [])
+    if isinstance(claims_data, list):
+        for i, claim in enumerate(claims_data[:5]):
+            if isinstance(claim, dict):
+                claim_text = claim.get('claim_text', '') or claim.get('text', '')
+                if claim_text:
+                    text += claim_text + " "
+            elif isinstance(claim, str):
+                text += claim + " "
+    elif isinstance(claims_data, dict):
+        claims_list = claims_data.get('claims', [])
+        for i, claim in enumerate(claims_list[:5]):
+            if isinstance(claim, dict):
+                claim_text = claim.get('claim_text', '') or claim.get('text', '')
+                if claim_text:
+                    text += claim_text + " "
+
+    # キーワードスコア
+    score = 0
+    for kw, weight in keyword_weights.items():
+        if kw in text:
+            score += weight * 10
+
+    # F-タームボーナス（遊技機の場合は10倍）
+    candidate_fterms = candidate.get('f_terms', [])
+    if not candidate_fterms:
+        candidate_fterms = candidate.get('bibliographic', {}).get('f_terms', [])
+    common_fterms = set(syutugan_fterms) & set(candidate_fterms)
+
+    # 遊技機(A63F)の場合はF-タームボーナスを大幅増加
+    fterm_bonus = 1000 if is_gaming_machine else 100
+    score += len(common_fterms) * fterm_bonus
+
+    return score
+
+
+def filter_by_date(scored_candidates, syutugan_patent, years=10):
+    """発行日でフィルタリング（10年以内）"""
+    container = _get_container()
+    syutugan_date_str = syutugan_patent.get('bibliographic', {}).get('publication', {}).get('date', '')
+
+    if not syutugan_date_str:
+        print("  警告: 出願特許の発行日が取得できません")
+        return scored_candidates
+
+    try:
+        syutugan_year = int(syutugan_date_str[:4])
+    except:
+        return scored_candidates
+
+    min_year = syutugan_year - years
+
+    print(f"  発行日フィルタ: {min_year}年以降")
+
+    filtered = []
+    for doc_num, score in scored_candidates:
+        query = f"SELECT c.bibliographic.publication.date FROM c WHERE c.bibliographic.publication.doc_number = '{doc_num}'"
+        items = list(container.query_items(query=query, enable_cross_partition_query=True))
+
+        if items:
+            date_str = items[0].get('date', '')
+            if date_str:
+                try:
+                    year = int(date_str[:4])
+                    if year >= min_year:
+                        filtered.append((doc_num, score))
+                except:
+                    filtered.append((doc_num, score))
+            else:
+                filtered.append((doc_num, score))
+
+    return filtered
+
+
+def save_results_to_csv(patent_id, scored_candidates, output_path=None):
+    """結果をCSVとして保存"""
+    os.makedirs(OUTPUT_FOLDER, exist_ok=True)
+
+    if output_path is None:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = os.path.join(OUTPUT_FOLDER, f"{patent_id}_results_{timestamp}.csv")
+
+    with open(output_path, 'w', encoding='utf-8', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(['rank', 'patent_number', 'score'])
+
+        for rank, (doc_num, score) in enumerate(scored_candidates, 1):
+            # doc_numberからJP形式に変換
+            patent_num = f"JP{doc_num}A" if not doc_num.startswith('JP') else doc_num
+            writer.writerow([rank, patent_num, score])
+
+    print(f"結果保存: {output_path}")
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description='特許検索パイプライン')
+    parser.add_argument('patent_id', help='検索対象の特許番号 (例: JP2021106667A)')
+    parser.add_argument('--filter-years', action='store_true',
+                        help='10,000件以上の場合、発行日10年以内で絞り込む')
+    parser.add_argument('--output', '-o', help='出力CSVファイルパス')
+
+    args = parser.parse_args()
+
+    patent_id = args.patent_id
+
+    print("="*80)
+    print("特許検索パイプライン")
+    print("="*80)
+    print(f"対象特許: {patent_id}")
+    print()
+
+    start_time = time.time()
+
+    # 1. 特許データ取得
+    print("【STEP1】特許データ取得...")
+    patent = load_patent_from_folder(patent_id)
+
+    if patent:
+        print(f"  ローカルファイルから読み込み: {INPUT_FOLDER}/{patent_id}.json")
+    else:
+        print(f"  ローカルにないためCosmosDBからダウンロード...")
+        patent = download_patent_from_cosmos(patent_id)
+
+        if not patent:
+            print(f"  エラー: 特許 {patent_id} が見つかりません")
+            return
+
+    # 特許情報表示
+    title = patent.get('bibliographic', {}).get('invention_title', '')
+    ipc_list = patent.get('bibliographic', {}).get('classification', {}).get('ipc_prefix', [])
+
+    print(f"  タイトル: {title[:50]}...")
+    print(f"  IPC: {ipc_list[:3]}")
+    print()
+
+    # 2. キーワード抽出
+    print("【STEP2】キーワード抽出...")
+
+    abstract = patent.get('abstract', '')
+    claims_data = patent.get('claims', [])
+    claims_texts = []
+    if isinstance(claims_data, list):
+        claims_texts = [c.get('claim_text', '') for c in claims_data[:3] if isinstance(c, dict)]
+    elif isinstance(claims_data, dict):
+        claims_list = claims_data.get('claims', [])
+        claims_texts = [c.get('claim_text', '') for c in claims_list[:3] if isinstance(c, dict)]
+
+    keywords = extract_keywords_with_priority(
+        title,
+        abstract if isinstance(abstract, str) else str(abstract),
+        claims_texts
+    )
+
+    total_keywords = sum(len(keywords.get(cat, [])) for cat in ['B_MUST', 'B_SHOULD', 'C_MUST', 'C_SHOULD'])
+    print(f"  抽出キーワード: {total_keywords}件")
+    print()
+
+    # 3. STAGE1: IPCフィルタリング
+    print("【STEP3】STAGE1: IPCフィルタリング...")
+    candidates = stage1_ipc_filter(patent)
+    print(f"  候補数: {len(candidates):,}件")
+    print()
+
+    # 4. STAGE2: キーワードスコアリング
+    print("【STEP4】STAGE2: キーワードスコアリング...")
+    scored = stage2_keyword_scoring_fast(candidates, keywords, patent, limit=10000)
+    print(f"  スコアリング完了: {len(scored):,}件")
+    print()
+
+    # 5. (オプション) 発行日フィルタ
+    if args.filter_years and len(scored) >= 10000:
+        print("【STEP5】発行日フィルタリング...")
+        scored = filter_by_date(scored, patent, years=10)
+        print(f"  フィルタ後: {len(scored):,}件")
+        print()
+
+    # 6. 結果をCSVに保存
+    print("【STEP6】結果保存...")
+    output_path = save_results_to_csv(patent_id, scored, args.output)
+
+    elapsed = time.time() - start_time
+
+    # サマリー表示
+    print()
+    print("="*80)
+    print("【処理完了】")
+    print("="*80)
+    print(f"対象特許: {patent_id}")
+    print(f"STAGE1候補: {len(candidates):,}件")
+    print(f"最終結果: {len(scored):,}件")
+    print(f"処理時間: {elapsed:.1f}秒")
+    print(f"出力ファイル: {output_path}")
+    print()
+
+    # 上位10件を表示
+    print("上位10件:")
+    for rank, (doc_num, score) in enumerate(scored[:10], 1):
+        patent_num = f"JP{doc_num}A" if not doc_num.startswith('JP') else doc_num
+        print(f"  {rank}位: {patent_num} ({score:.0f}点)")
+
+
+if __name__ == "__main__":
+    main()

--- a/prod-search-patent/src/pipeline/pipeline_runner.py
+++ b/prod-search-patent/src/pipeline/pipeline_runner.py
@@ -21,6 +21,7 @@ from .parsing_service import load_json_document, parse_text_document
 from .query_generation import QueryGenerator
 from .stage2_indexer import Stage2Indexer
 from .trimming import sort_and_trim
+from .patent_search_pipeline import run_patent_search_from_json
 
 logger = logging.getLogger(__name__)
 QUERY_OUTPUT_DIR = Path(__file__).resolve().parents[3] / "query"
@@ -186,58 +187,133 @@ async def run_pipeline(
     tracker.complete("parsing")
 
     ipc_codes = parsed["classification_ipc"]
+    logger.info("Job %s: IPC codes from parsed document: %s", job_id, ipc_codes[:10] if ipc_codes else [])
+    logger.info("Job %s: es_stage1_limit = %d", job_id, config.es_stage1_limit)
 
-    # Stage 2: Cosmos query
-    tracker.start("cosmos_query", {"ipc_codes": ipc_codes})
+    # Stage 2: Keyword search (IPC filtering + keyword scoring)
+    # Note: cosmos_query was removed as keyword_search already includes IPC filtering in STAGE1
+    tracker.start("keyword_search", {"ipc_codes": ipc_codes})
+
+    # Build Cosmos-format JSON for keyword search
+    # Use source_json if available, otherwise build from parsed data
+    import re
+
+    source_json = parsed.get("source_json")
+    if source_json and isinstance(source_json, dict):
+        # source_jsonがある場合、それをベースにipc_prefixを追加
+        cosmos_format_json = dict(source_json)
+
+        # ipc_prefixを計算して追加（patent_search_pipelineが期待する形式）
+        ipc_prefixes = []
+        for ipc in ipc_codes:
+            ipc_str = ipc if isinstance(ipc, str) else ""
+            if ipc_str and len(ipc_str) >= 4:
+                s = ipc_str.upper()
+                if "/" in s:
+                    s = s.split("/", 1)[0]
+                cleaned = re.sub(r"\s+", "", s)[:5]
+                if cleaned and cleaned not in ipc_prefixes:
+                    ipc_prefixes.append(cleaned)
+
+        # bibliographic.classification.ipc_prefixを設定
+        if "bibliographic" not in cosmos_format_json:
+            cosmos_format_json["bibliographic"] = {}
+        if "classification" not in cosmos_format_json["bibliographic"]:
+            cosmos_format_json["bibliographic"]["classification"] = {}
+        cosmos_format_json["bibliographic"]["classification"]["ipc_prefix"] = ipc_prefixes
+
+        # claimsをclaim_text形式に変換（patent_search_pipelineが期待する形式）
+        original_claims = cosmos_format_json.get("claims", [])
+        converted_claims = []
+        for claim in original_claims:
+            if isinstance(claim, dict):
+                text = claim.get("text") or claim.get("claim_text", "")
+                if text:
+                    converted_claims.append({"claim_text": text})
+        if not converted_claims and parsed.get("claim1"):
+            converted_claims.append({"claim_text": parsed.get("claim1")})
+        cosmos_format_json["claims"] = converted_claims
+
+        # invention_titleを設定（titleがある場合）
+        if "bibliographic" in cosmos_format_json:
+            if "title" in cosmos_format_json["bibliographic"] and "invention_title" not in cosmos_format_json["bibliographic"]:
+                cosmos_format_json["bibliographic"]["invention_title"] = cosmos_format_json["bibliographic"]["title"]
+
+        logger.info("Job %s: Using source_json for keyword search, ipc_prefixes=%s", job_id, ipc_prefixes[:3])
+    else:
+        # source_jsonがない場合、parsedデータから構築
+        claims = parsed.get("claims") or []
+        claim_entries = []
+        for claim in claims:
+            text = (claim or {}).get("text")
+            if text:
+                claim_entries.append({"claim_text": text})
+        if not claim_entries and parsed.get("claim1"):
+            claim_entries.append({"claim_text": parsed.get("claim1")})
+
+        # Get IPC prefixes
+        ipc_prefixes = []
+        for ipc in ipc_codes:
+            ipc_str = ipc if isinstance(ipc, str) else ""
+            if ipc_str and len(ipc_str) >= 4:
+                s = ipc_str.upper()
+                if "/" in s:
+                    s = s.split("/", 1)[0]
+                cleaned = re.sub(r"\s+", "", s)[:5]
+                if cleaned and cleaned not in ipc_prefixes:
+                    ipc_prefixes.append(cleaned)
+
+        cosmos_format_json = {
+            "bibliographic": {
+                "invention_title": parsed.get("title", ""),
+                "publication": {"doc_number": parsed.get("patent_id", "")},
+                "classification": {
+                    "ipc_prefix": ipc_prefixes
+                }
+            },
+            "abstract": parsed.get("summary", ""),
+            "claims": claim_entries,
+            "description": None,
+        }
+
+        logger.info("Job %s: Built cosmos_format_json from parsed data, ipc_prefixes=%s", job_id, ipc_prefixes[:3])
+
+    # Run keyword search pipeline
+    search_result = run_patent_search_from_json(cosmos_format_json, job_manager, job_id)
+
+    narrowed_patent_ids = search_result.get("keyword_search_results", [])
+    logger.info("Job %s: Keyword search returned %d patents", job_id, len(narrowed_patent_ids))
+
+    tracker.update("keyword_search", {
+        "narrowed_count": len(narrowed_patent_ids),
+        "stage1_IPC_candidates": search_result.get("pipeline_stats", {}).get("stage1_IPC_candidates", 0),
+        "stage2_keyword_filter_results": search_result.get("pipeline_stats", {}).get("stage2_keyword_filter_results", 0),
+    })
+    tracker.complete("keyword_search")
+
+    # Use narrowed patent_ids for subsequent processing
+    # Fetch documents from Cosmos for the narrowed patents
     cosmos_client = CosmosPatentClient(config)
     try:
-        cosmos_docs = cosmos_client.query_by_ipc_prefixes(ipc_codes, config.es_stage1_limit)
+        narrowed_cosmos_map = cosmos_client.fetch_by_patent_ids(narrowed_patent_ids[:config.es_stage1_limit])
     finally:
         cosmos_client.close()
 
-    if not cosmos_docs:
-        tracker.update(
-            "cosmos_query",
-            {
-                "matched_documents": 0,
-            },
-        )
-        raise IngestionError("Cosmos query returned no documents", status_code=404)
-
-    tracker.update(
-        "cosmos_query",
-        {
-            "matched_documents": len(cosmos_docs),
-        },
-    )
-
-    tracker.complete("cosmos_query")
-
-    # Stage 3: Trimming to Stage1 limit
-    tracker.start("trimming")
-    trimmed_docs_raw = sort_and_trim(cosmos_docs, config.es_stage1_limit)
-
     trimmed_docs: List[Dict] = []
     seen_trimmed: set[str] = set()
-    for doc in trimmed_docs_raw:
-        bibliographic = doc.get("bibliographic") or {}
-        publication = bibliographic.get("publication") or {}
-        patent_id = doc.get("patent_id") or doc.get("id") or publication.get("doc_number")
-        if not patent_id:
+    for patent_id in narrowed_patent_ids[:config.es_stage1_limit]:
+        if patent_id in seen_trimmed:
             continue
-        patent_id_str = str(patent_id)
-        if patent_id_str in seen_trimmed:
-            continue
-        seen_trimmed.add(patent_id_str)
+        seen_trimmed.add(patent_id)
+        cosmos_doc = narrowed_cosmos_map.get(patent_id, {})
         trimmed_docs.append(
             {
                 "patent_id": patent_id,
-                "title": doc.get("title") or parsed.get("title"),
-                "summary": doc.get("abstract") or doc.get("summary") or parsed.get("summary"),
-                "claim1": doc.get("claim1") or parsed.get("claim1"),
+                "title": cosmos_doc.get("title") or parsed.get("title"),
+                "summary": cosmos_doc.get("abstract") or cosmos_doc.get("summary") or parsed.get("summary"),
+                "claim1": cosmos_doc.get("claim1") or parsed.get("claim1"),
             }
         )
-    tracker.complete("trimming")
 
     stage1 = Stage1ElasticsearchIndexer(config)
     stage1.ensure_index()


### PR DESCRIPTION
- LLMベースのキーワード抽出機能を追加（abc_keyword_extractor_v3.py）
- 2段階フィルタリング実装（IPC → キーワードスコアリング）
- 検索対象にtitle、請求項1〜5を追加
- Redis key名を変更: keyword_search_results, stage1_IPC_candidates, stage2_keyword_filter_results
- キーワード検索結果モーダルUI追加（10,000件表示）
- ステージラベル日本語化（完了/実行中/待機中）
- テスト用特許番号入力機能追加（CosmosDB直接参照）
- Azure SDKログ抑制
- 完了済みジョブでも件数リンク表示

