### PR TITLE
fix: ジョブpayloadのTTLを1時間から24時間に延長

### DIFF
--- a/prod-search-patent/src/pipeline/job_manager.py
+++ b/prod-search-patent/src/pipeline/job_manager.py
@@ -42,7 +42,7 @@ class JobManager:
         return JobState(status=payload.get("status", "unknown"), detail=payload.get("detail", {}))
 
     def store_payload(self, job_id: str, payload: dict) -> None:
-        self.client.set(f"job_payload:{job_id}", json.dumps(payload), ex=60 * 60)
+        self.client.set(f"job_payload:{job_id}", json.dumps(payload), ex=60 * 60 * 24)  # 24 hours
 
     def fetch_payload(self, job_id: str) -> Optional[dict]:
         value = self.client.get(f"job_payload:{job_id}")


### PR DESCRIPTION
大量のジョブを一度に投入した際、処理待ちのジョブのpayloadが
1時間のTTL切れで削除され、payload_missingエラーが発生する問題を修正。

- job_manager.pyのstore_payloadメソッドでTTLを24時間に変更
- これにより、大量ジョブの一括投入時も全ジョブが正常に処理可能